### PR TITLE
Format Code

### DIFF
--- a/examples/trilogy/src/main.rs
+++ b/examples/trilogy/src/main.rs
@@ -6,8 +6,8 @@ extern crate env_logger;
 extern crate graphql;
 extern crate graphql_macros;
 
-use graphql::{QlResult, QlError};
-use graphql::types::{self, Id, Name, query, result, schema};
+use graphql::{QlError, QlResult};
+use graphql::types::{self, query, result, schema, Id, Name};
 use graphql::types::schema::{Reflect, ResolveEnum, ResolveObject};
 use graphql::types::query::FromValue;
 use graphql::types::result::Resolve;
@@ -48,7 +48,7 @@ schema! {
 
 fn main() {
     env_logger::init().unwrap();
-    
+
     let query = "{
       human(id: 1002) {
         name,
@@ -62,7 +62,6 @@ fn main() {
         Err(err) => println!("{:?}", err),
     }
 }
-
 
 struct Service;
 
@@ -124,7 +123,6 @@ ImplQuery!(DbQuery);
 //     }
 // }
 
-
 // TODO remove the below at some point, or replace with the actual output from `schema!`.
 // Currently contains a bunch of TODOs/notes I'd like to keep.
 mod example_generated {
@@ -161,7 +159,7 @@ mod example_generated {
     //                         assert_eq!(field.args.len(), 0);
     //                         let result = self.query()?;
     //                         let result = result.resolve(&field.fields)?;
-                            
+
     //                         // This is a special case where the result doesn't match the query
     //                         results.push((types::Name("data".to_owned()), result));
     //                     }
@@ -232,7 +230,7 @@ mod example_generated {
     //                         let episode: Option<<Self as AbstractQuery>::Episode> = FromValue::from(value)?;
     //                         let result = self.hero(episode)?;
     //                         let result = result.resolve(&field.fields)?;
-                            
+
     //                         results.push((types::Name("hero".to_owned()), result));
     //                     }
     //                     "human" => {
@@ -242,7 +240,7 @@ mod example_generated {
     //                         let id: Id = FromValue::from(value)?;
     //                         let result = self.human(id)?;
     //                         let result = result.resolve(&field.fields)?;
-                            
+
     //                         results.push((types::Name("human".to_owned()), result));
     //                     }
     //                     n => return Err(QlError::ExecutionError(format!("Missing field executor: {}", n))),
@@ -370,7 +368,6 @@ mod example_generated {
     // }
 
     // impl AbstractCharacter for Character {}
-
 
     // pub trait AbstractEpisode: ResolveEnum {}
 

--- a/graphql-macros/src/ir.rs
+++ b/graphql-macros/src/ir.rs
@@ -1,7 +1,7 @@
-use graphql::types::{Name, schema};
+use graphql::types::{schema, Name};
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
-use proc_macro::{TokenStream, quote};
+use proc_macro::{quote, TokenStream};
 
 #[derive(Clone, Debug)]
 pub struct Schema {
@@ -103,7 +103,11 @@ pub enum TypeKind {
 
 pub fn lower_schema(schema: &schema::Schema) -> Schema {
     Schema {
-        items: schema.items.iter().map(|(n, i)| (n.clone(), lower_item(n, i))).collect(),
+        items: schema
+            .items
+            .iter()
+            .map(|(n, i)| (n.clone(), lower_item(n, i)))
+            .collect(),
     }
 }
 
@@ -173,7 +177,11 @@ fn lower_enum(name: &Name, e: &schema::Enum) -> Enum {
 fn lower_field(field: &schema::Field) -> Field {
     Field {
         name: field.name.clone(),
-        args: field.args.iter().map(|&(ref n, ref t)| (n.clone(), lower_type(t))).collect(),
+        args: field
+            .args
+            .iter()
+            .map(|&(ref n, ref t)| (n.clone(), lower_type(t)))
+            .collect(),
         ty: lower_type(&field.ty),
     }
 }
@@ -189,4 +197,3 @@ fn lower_type(ty: &schema::Type) -> Type {
         nullable: ty.nullable,
     }
 }
-

--- a/graphql/src/execution.rs
+++ b/graphql/src/execution.rs
@@ -1,8 +1,14 @@
 use QlResult;
 use types::{query, result, schema};
 
-pub fn select_fields<O: schema::ResolveObject>(object: &O, fields: &[query::Field]) -> QlResult<result::Value> {
+pub fn select_fields<O: schema::ResolveObject>(
+    object: &O,
+    fields: &[query::Field],
+) -> QlResult<result::Value> {
     Ok(result::Value::Object(result::Object {
-        fields: fields.iter().map(|f| Ok((f.name.clone(), object.resolve_field(f)?))).collect::<QlResult<Vec<_>>>()?,
+        fields: fields
+            .iter()
+            .map(|f| Ok((f.name.clone(), object.resolve_field(f)?)))
+            .collect::<QlResult<Vec<_>>>()?,
     }))
 }

--- a/graphql/src/parser/lexer.rs
+++ b/graphql/src/parser/lexer.rs
@@ -5,11 +5,10 @@ use std::iter::Peekable;
 use std::mem;
 use std::str::{CharIndices, FromStr};
 
-
 pub fn tokenise<'a>(input: &'a str) -> QlResult<Vec<Token<'a>>> {
     let lexer = Lexer::new(input);
     lexer.tokenise()
-} 
+}
 
 // pub type Span = ::rls_span::Span<::rls_span::ZeroIndexed>;
 
@@ -27,7 +26,6 @@ pub enum LexError {
 macro lex_err($kind: ident $(, $body: expr)*) {
     Err(QlError::LexError(LexError::$kind($($body,)*)))
 }
-
 
 struct Lexer<'a> {
     input: &'a str,
@@ -61,12 +59,10 @@ impl<'a> Lexer<'a> {
                 '[' => self.open_bracket(Bracket::Square),
                 '(' => self.open_bracket(Bracket::Paren),
 
-                '"' => {
-                    match self.string {
-                        Some(_) => self.close_string(i),
-                        None => self.open_string(i),
-                    }
-                }
+                '"' => match self.string {
+                    Some(_) => self.close_string(i),
+                    None => self.open_string(i),
+                },
 
                 '\n' => {
                     // TODO span stuff
@@ -267,7 +263,10 @@ mod test {
         let lexer = Lexer::new(input);
         let result = lexer.tokenise().unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].to_string().replace(' ', ""), input.replace(' ', ""));
+        assert_eq!(
+            result[0].to_string().replace(' ', ""),
+            input.replace(' ', "")
+        );
     }
 
     // TODO test: errors

--- a/graphql/src/parser/parse_base.rs
+++ b/graphql/src/parser/parse_base.rs
@@ -1,9 +1,9 @@
 // Code which is shared between the IDL and query parsers
 
-use {ParseError, QlResult, QlError};
+use {ParseError, QlError, QlResult};
 use parser::lexer::tokenise;
 use parser::token::{Atom, Bracket, Token, TokenKind};
-use schema::{Field, Item, Interface, Object, Enum, Type, Schema};
+use schema::{Enum, Field, Interface, Item, Object, Schema, Type};
 use types::Name;
 
 pub struct TokenStream<'a> {
@@ -12,9 +12,7 @@ pub struct TokenStream<'a> {
 
 impl<'a> TokenStream<'a> {
     pub fn new(tokens: &'a [Token<'a>]) -> TokenStream<'a> {
-        TokenStream {
-            tokens,
-        }
+        TokenStream { tokens }
     }
 
     pub fn next_tok(&mut self) -> QlResult<&'a Token<'a>> {
@@ -38,7 +36,7 @@ impl<'a> TokenStream<'a> {
     pub fn eat(&mut self, atom: Atom<'a>) -> QlResult<()> {
         match self.next_tok()?.kind {
             TokenKind::Atom(a) if a == atom => Ok(()),
-            _ => parse_err!("Unexpected token")
+            _ => parse_err!("Unexpected token"),
         }
     }
 
@@ -63,14 +61,14 @@ impl<'a> TokenStream<'a> {
 
     pub fn expect<F, T>(&mut self, f: F) -> QlResult<T>
     where
-        F: Fn(&mut TokenStream) -> QlResult<Option<T>>
+        F: Fn(&mut TokenStream) -> QlResult<Option<T>>,
     {
         f(self).and_then(|n| n.ok_or_else(|| QlError::ParseError(ParseError("Unexpected eof"))))
     }
 
     pub fn parse_list<F, T>(&mut self, f: F) -> QlResult<Vec<T>>
     where
-        F: Fn(&mut TokenStream) -> QlResult<Option<T>>
+        F: Fn(&mut TokenStream) -> QlResult<Option<T>>,
     {
         self.ignore_newlines();
 
@@ -80,13 +78,13 @@ impl<'a> TokenStream<'a> {
             self.maybe_eat(Atom::Comma);
             self.ignore_newlines();
         }
-        
+
         Ok(result)
     }
 
     pub fn maybe_parse_seq<F, T>(&mut self, opener: Bracket, f: F) -> QlResult<Vec<T>>
     where
-        F: Fn(&mut TokenStream) -> QlResult<Vec<T>>
+        F: Fn(&mut TokenStream) -> QlResult<Vec<T>>,
     {
         if let Some(tok) = self.peek_tok() {
             if let TokenKind::Tree(br, ref toks) = tok.kind {
@@ -102,7 +100,9 @@ impl<'a> TokenStream<'a> {
 
 pub fn maybe_parse_name(stream: &mut TokenStream) -> QlResult<Option<Name>> {
     match *none_ok!(stream.peek_tok()) {
-        Token { kind: TokenKind::Atom(Atom::Name(s))} => {
+        Token {
+            kind: TokenKind::Atom(Atom::Name(s)),
+        } => {
             stream.bump();
             Ok(Some(Name(s.to_owned())))
         }
@@ -120,7 +120,6 @@ pub macro none_ok($e: expr) {
         None => return Ok(None),
     }
 }
-
 
 #[cfg(test)]
 mod test {

--- a/graphql/src/parser/parse_query.rs
+++ b/graphql/src/parser/parse_query.rs
@@ -241,16 +241,19 @@ mod test {
         let result = parse_operation(&mut ts).unwrap();
         if let Query::Query(fields) = result {
             assert_eq!(fields.len(), 1);
-            assert_eq!(&*fields[0].name.0, "human");
-            assert_eq!(fields[0].args.len(), 1);
+            println!("{:?}", fields);
+            assert_eq!(fields[0].name.0, "query");
+            assert_eq!(fields[0].args.len(), 0);
+            assert_eq!(fields[0].fields.len(), 1);
+            assert_eq!(fields[0].fields[0].name.0, "human");
             assert_eq!(
-                &fields[0].args[0],
+                &fields[0].fields[0].args[0],
                 &(Name("id".to_owned()), Value::Name(Name("1002".to_owned())))
             );
-            assert_eq!(fields[0].fields.len(), 3);
-            assert_eq!(fields[0].fields[0].name.0, "name");
-            assert_eq!(fields[0].fields[1].name.0, "appearsIn");
-            assert_eq!(fields[0].fields[2].name.0, "id");
+            assert_eq!(fields[0].fields[0].fields.len(), 3);
+            assert_eq!(fields[0].fields[0].fields[0].name.0, "name");
+            assert_eq!(fields[0].fields[0].fields[1].name.0, "appearsIn");
+            assert_eq!(fields[0].fields[0].fields[2].name.0, "id");
         } else {
             panic!();
         }

--- a/graphql/src/parser/parse_query.rs
+++ b/graphql/src/parser/parse_query.rs
@@ -1,6 +1,6 @@
-use {ParseError, QlResult, QlError};
+use {ParseError, QlError, QlResult};
 use parser::lexer::tokenise;
-use parser::parse_base::{none_ok, parse_err, TokenStream, maybe_parse_name};
+use parser::parse_base::{maybe_parse_name, none_ok, parse_err, TokenStream};
 use parser::token::{Atom, Bracket, Token, TokenKind};
 use query::{Field, Query, Value};
 use types::Name;
@@ -21,12 +21,14 @@ fn parse_operation(stream: &mut TokenStream) -> QlResult<Query> {
                 }
                 _ => return parse_err!("Unexpected token, expected: `{`"),
             };
-            Ok(Query::Query(vec![Field {
-                name: Name("query".to_owned()),
-                alias: None,
-                args: vec![],
-                fields: body,
-            }]))
+            Ok(Query::Query(vec![
+                Field {
+                    name: Name("query".to_owned()),
+                    alias: None,
+                    args: vec![],
+                    fields: body,
+                },
+            ]))
         }
         TokenKind::Atom(Atom::Name(n)) if n == "mutation" => {
             // TODO parse the body of the mutation
@@ -34,12 +36,14 @@ fn parse_operation(stream: &mut TokenStream) -> QlResult<Query> {
         }
         TokenKind::Tree(Bracket::Brace, ref toks) => {
             let body = parse_field_list(&mut TokenStream::new(toks))?;
-            Ok(Query::Query(vec![Field {
-                name: Name("query".to_owned()),
-                alias: None,
-                args: vec![],
-                fields: body,
-            }]))
+            Ok(Query::Query(vec![
+                Field {
+                    name: Name("query".to_owned()),
+                    alias: None,
+                    args: vec![],
+                    fields: body,
+                },
+            ]))
         }
         _ => parse_err!("Unexpected token, expected: identifier or `{`"),
     }
@@ -115,7 +119,6 @@ fn maybe_parse_fields(stream: &mut TokenStream) -> QlResult<Vec<Field>> {
     stream.maybe_parse_seq(Bracket::Brace, parse_field_list)
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -134,10 +137,27 @@ mod test {
         let tokens = tokenise("null \"foo\" 42 bar [null, null, foo, \"bar\"]").unwrap();
         let mut ts = TokenStream::new(&tokens);
         assert_eq!(parse_value(&mut ts).unwrap(), Value::Null);
-        assert_eq!(parse_value(&mut ts).unwrap(), Value::String("foo".to_owned()));
-        assert_eq!(parse_value(&mut ts).unwrap(), Value::Name(Name("42".to_owned())));
-        assert_eq!(parse_value(&mut ts).unwrap(), Value::Name(Name("bar".to_owned())));
-        assert_eq!(parse_value(&mut ts).unwrap(), Value::Array(vec![Value::Null, Value::Null, Value::Name(Name("foo".to_owned())), Value::String("bar".to_owned())]));
+        assert_eq!(
+            parse_value(&mut ts).unwrap(),
+            Value::String("foo".to_owned())
+        );
+        assert_eq!(
+            parse_value(&mut ts).unwrap(),
+            Value::Name(Name("42".to_owned()))
+        );
+        assert_eq!(
+            parse_value(&mut ts).unwrap(),
+            Value::Name(Name("bar".to_owned()))
+        );
+        assert_eq!(
+            parse_value(&mut ts).unwrap(),
+            Value::Array(vec![
+                Value::Null,
+                Value::Null,
+                Value::Name(Name("foo".to_owned())),
+                Value::String("bar".to_owned()),
+            ])
+        );
     }
 
     #[test]
@@ -148,7 +168,13 @@ mod test {
 
         let tokens = tokenise("(x: 42, foo: \"bar\")").unwrap();
         let mut ts = TokenStream::new(&tokens);
-        assert_eq!(maybe_parse_args(&mut ts).unwrap(), vec![(Name("x".to_owned()), Value::Name(Name("42".to_owned()))), (Name("foo".to_owned()), Value::String("bar".to_owned()))]);
+        assert_eq!(
+            maybe_parse_args(&mut ts).unwrap(),
+            vec![
+                (Name("x".to_owned()), Value::Name(Name("42".to_owned()))),
+                (Name("foo".to_owned()), Value::String("bar".to_owned())),
+            ]
+        );
     }
 
     #[test]
@@ -170,47 +196,57 @@ mod test {
             }
         }
 
-        let tokens = tokenise(r"{ a, foo, bar(x: 42)
+        let tokens = tokenise(
+            r"{ a, foo, bar(x: 42)
 
             baz {
                 a
                 b
-            }}").unwrap();
+            }}",
+        ).unwrap();
         let mut ts = TokenStream::new(&tokens);
-        assert_eq!(maybe_parse_fields(&mut ts).unwrap(), vec![
-            name_field("a"),
-            name_field("foo"),
-            Field {
-                name: Name("bar".to_owned()),
-                alias: None,
-                args: vec![(Name("x".to_owned()), Value::Name(Name("42".to_owned())))],
-                fields: vec![],
-            },
-            Field {
-                name: Name("baz".to_owned()),
-                alias: None,
-                args: vec![],
-                fields: vec![name_field("a"), name_field("b")],
-            },
-        ]);
+        assert_eq!(
+            maybe_parse_fields(&mut ts).unwrap(),
+            vec![
+                name_field("a"),
+                name_field("foo"),
+                Field {
+                    name: Name("bar".to_owned()),
+                    alias: None,
+                    args: vec![(Name("x".to_owned()), Value::Name(Name("42".to_owned())))],
+                    fields: vec![],
+                },
+                Field {
+                    name: Name("baz".to_owned()),
+                    alias: None,
+                    args: vec![],
+                    fields: vec![name_field("a"), name_field("b")],
+                },
+            ]
+        );
     }
 
     #[test]
     fn test_parse_query() {
-        let tokens = tokenise(r"{
+        let tokens = tokenise(
+            r"{
           human(id: 1002) {
             name,
             appearsIn,
             id
           }
-        }").unwrap();
+        }",
+        ).unwrap();
         let mut ts = TokenStream::new(&tokens);
         let result = parse_operation(&mut ts).unwrap();
         if let Query::Query(fields) = result {
             assert_eq!(fields.len(), 1);
             assert_eq!(&*fields[0].name.0, "human");
             assert_eq!(fields[0].args.len(), 1);
-            assert_eq!(&fields[0].args[0], &(Name("id".to_owned()), Value::Name(Name("1002".to_owned()))));
+            assert_eq!(
+                &fields[0].args[0],
+                &(Name("id".to_owned()), Value::Name(Name("1002".to_owned())))
+            );
             assert_eq!(fields[0].fields.len(), 3);
             assert_eq!(fields[0].fields[0].name.0, "name");
             assert_eq!(fields[0].fields[1].name.0, "appearsIn");

--- a/graphql/src/parser/token.rs
+++ b/graphql/src/parser/token.rs
@@ -64,7 +64,14 @@ mod display {
                 TokenKind::Atom(ref a) => a.fmt(f),
                 TokenKind::Tree(ref b, ref ts) => {
                     write!(f, "{}", b.open())?;
-                    write!(f, "{}", ts.iter().map(|t| t.to_string()).collect::<Vec<_>>().join(" "))?;
+                    write!(
+                        f,
+                        "{}",
+                        ts.iter()
+                            .map(|t| t.to_string())
+                            .collect::<Vec<_>>()
+                            .join(" ")
+                    )?;
                     write!(f, "{}", b.close())
                 }
             }

--- a/graphql/src/types/query.rs
+++ b/graphql/src/types/query.rs
@@ -8,9 +8,9 @@ query {
   }
 }
 */
-use {QlResult, QlError};
+use {QlError, QlResult};
 use parser::parse_query::parse_query;
-use types::{Name, Id, result, schema};
+use types::{result, schema, Id, Name};
 
 // TODO variables, directives
 // TODO rename as Operation
@@ -84,7 +84,10 @@ impl FromValue for String {
         if let Value::String(ref s) = *value {
             Ok(s.clone())
         } else {
-            Err(QlError::LoweringError(format!("{:?}", value), "String".to_owned()))
+            Err(QlError::LoweringError(
+                format!("{:?}", value),
+                "String".to_owned(),
+            ))
         }
     }
 }
@@ -93,7 +96,10 @@ impl FromValue for Id {
         if let Value::Name(ref n) = *value {
             Ok(Id(n.0.clone()))
         } else {
-            Err(QlError::LoweringError(format!("{:?}", value), "Id".to_owned()))
+            Err(QlError::LoweringError(
+                format!("{:?}", value),
+                "Id".to_owned(),
+            ))
         }
     }
 }
@@ -102,7 +108,10 @@ impl FromValue for Name {
         if let Value::Name(ref n) = *value {
             Ok(n.clone())
         } else {
-            Err(QlError::LoweringError(format!("{:?}", value), "Name".to_owned()))
+            Err(QlError::LoweringError(
+                format!("{:?}", value),
+                "Name".to_owned(),
+            ))
         }
     }
 }
@@ -111,7 +120,10 @@ impl<T: FromValue> FromValue for Vec<T> {
         if let Value::Array(ref a) = *value {
             a.iter().map(|x| T::from(x)).collect()
         } else {
-            Err(QlError::LoweringError(format!("{:?}", value), "Array".to_owned()))
+            Err(QlError::LoweringError(
+                format!("{:?}", value),
+                "Array".to_owned(),
+            ))
         }
     }
 }

--- a/graphql/src/types/result.rs
+++ b/graphql/src/types/result.rs
@@ -64,10 +64,11 @@ impl<T: Resolve> Resolve for Option<T> {
 impl<T: Resolve> Resolve for Vec<T> {
     fn resolve(&self, fields: &[query::Field]) -> QlResult<Value> {
         // TODO collect all errors not just one
-        Ok(Value::Array(self.iter().map(|t| t.resolve(fields)).collect::<Result<Vec<_>, _>>()?))
+        Ok(Value::Array(self.iter()
+            .map(|t| t.resolve(fields))
+            .collect::<Result<Vec<_>, _>>()?))
     }
 }
-
 
 mod display {
     use super::*;

--- a/graphql/src/types/schema.rs
+++ b/graphql/src/types/schema.rs
@@ -25,7 +25,9 @@ impl Schema {
 pub fn schema_type() -> Item {
     Item::Object(Object {
         implements: vec![],
-        fields: vec![Field::fun(Name("query".to_owned()), vec![], Type::name("Query"))]
+        fields: vec![
+            Field::fun(Name("query".to_owned()), vec![], Type::name("Query")),
+        ],
     })
 }
 
@@ -42,8 +44,7 @@ pub trait ResolveObject: Reflect + result::Resolve {
     fn resolve_field(&self, field: &query::Field) -> QlResult<result::Value>;
 }
 
-pub trait ResolveEnum: Reflect + result::Resolve {
-}
+pub trait ResolveEnum: Reflect + result::Resolve {}
 
 #[derive(Clone, Debug)]
 pub enum Item {
@@ -97,11 +98,7 @@ impl Field {
     }
 
     pub fn fun(name: Name, args: Vec<(Name, Type)>, ty: Type) -> Field {
-        Field {
-            name,
-            args,
-            ty,
-        }
+        Field { name, args, ty }
     }
 }
 
@@ -153,6 +150,5 @@ impl Type {
             TypeKind::Name(ref n) => Some(n),
             _ => None,
         }
-
     }
 }


### PR DESCRIPTION
This PR is to address #17.

I noticed a failing test, so I took care of that while I was at it.

When I ran `cargo fmt` I noticed these errors:

```
error: line exceeded maximum width (maximum: 100, found: 108)
   --> /home/scrogson/github/nrc/graphql/graphql-macros/src/lib.rs:209
    |
209 |                     _ => return Err(QlError::LoweringError(format!("{:?}", value), $expect_str.to_owned())),
    |                                                                                                     ^^^^^^^^
error: line exceeded maximum width (maximum: 100, found: 132)
   --> /home/scrogson/github/nrc/graphql/graphql-macros/src/lib.rs:423
    |
423 |                                 n => return Err(QlError::ExecutionError(format!("Missing field executor in {}: {}", $name_str, n))),
    |                                                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
error: line exceeded maximum width (maximum: 100, found: 102)
   --> /home/scrogson/github/nrc/graphql/graphql-macros/src/lib.rs:454
    |
454 |                         _ => return Err(QlError::ResolveError("field", field.name.to_string(), None)),
    |                                                                                                     ^^
error: line exceeded maximum width (maximum: 100, found: 102)
   --> /home/scrogson/github/nrc/graphql/graphql-macros/src/lib.rs:533
    |
533 |                                     // This is a special case where the result doesn't match the query
    |                                                                                                     ^^
error: line exceeded maximum width (maximum: 100, found: 110)
   --> /home/scrogson/github/nrc/graphql/graphql-macros/src/lib.rs:590
    |
590 |             quote!($name_str => result.push((types::Name($name_str.to_owned()), self.resolve_field(field)?)),)
    |                                                                                                     ^^^^^^^^^^
warning: rustfmt may have failed to format. See previous 5 errors.
```

Unfortunately, I'm not sure how I should go about fixing those idiomatically.