### PR TITLE
Suppress Warnings

### DIFF
--- a/graphql/src/parser/parse_base.rs
+++ b/graphql/src/parser/parse_base.rs
@@ -1,9 +1,7 @@
 // Code which is shared between the IDL and query parsers
 
 use {ParseError, QlError, QlResult};
-use parser::lexer::tokenise;
 use parser::token::{Atom, Bracket, Token, TokenKind};
-use schema::{Enum, Field, Interface, Item, Object, Schema, Type};
 use types::Name;
 
 pub struct TokenStream<'a> {
@@ -124,6 +122,7 @@ pub macro none_ok($e: expr) {
 #[cfg(test)]
 mod test {
     use super::*;
+    use parser::lexer::tokenise;
 
     #[test]
     fn test_bump() {

--- a/graphql/src/parser/parse_idl.rs
+++ b/graphql/src/parser/parse_idl.rs
@@ -1,6 +1,6 @@
 // Parses an IDL representation of a schema.
 
-use {ParseError, QlError, QlResult};
+use QlResult;
 use parser::lexer::tokenise;
 use parser::parse_base::{maybe_parse_name, none_ok, parse_err, TokenStream};
 use parser::token::{Atom, Bracket, Token, TokenKind};

--- a/graphql/src/parser/parse_query.rs
+++ b/graphql/src/parser/parse_query.rs
@@ -1,7 +1,7 @@
-use {ParseError, QlError, QlResult};
+use QlResult;
 use parser::lexer::tokenise;
 use parser::parse_base::{maybe_parse_name, none_ok, parse_err, TokenStream};
-use parser::token::{Atom, Bracket, Token, TokenKind};
+use parser::token::{Atom, Bracket, TokenKind};
 use query::{Field, Query, Value};
 use types::Name;
 

--- a/graphql/src/validation/mod.rs
+++ b/graphql/src/validation/mod.rs
@@ -185,6 +185,4 @@ fn get_field<'a>(fields: &'a [schema::Field], name: &Name) -> Option<&'a schema:
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
 }


### PR DESCRIPTION
This PR fixes #21.

I'm not quite sure if adding the `#[allow(dead_code)]` for the `K*` structs is the correct way to handle that or not.

I'm not sure why rust is complaining about those. Maybe a bug?
  