### PR TITLE
Ignore all 'target' dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
-/target/
+target/
 **/*.rs.bk
 Cargo.lock


### PR DESCRIPTION
The `graphql/target` directory isn't getting ignored by default.